### PR TITLE
Update pyproject.toml to update version and fix dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deeprhythm"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
   { name="bleugreen", email="bleugreendesign@gmail.com" },
 ]
@@ -22,6 +22,7 @@ dependencies = [
   "nnaudio==0.3.3",
   "librosa",
   "numpy",
+  "h5py",
 ]
 
 [project.urls]


### PR DESCRIPTION
Updated pyproject.toml 

- Version was 0.0.12 not 0.0.13.
- h5py was missing as dependency but present in requirements and some modules.
